### PR TITLE
Fixes #9. Adds GitHub issues and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,75 @@
+---
+name: Bug report
+about: Create a report about a specific issue
+title: 'Bug Report'
+labels: 'verify'
+assignees: ''
+
+---
+
+**NOTE**: This issue tracker is for reporting bugs encountered with the
+Herald API and Herald testing applications themselves, not for issues with any downstream
+projects that use Herald within their apps. Please report issues with those apps to their
+developers and allow those developers to raise any upstream issues
+here themselves after they have completed their initial issue investigation. This prevents
+rework and delay in getting your issues resolved. Any issues
+raised referring to those apps here and not Herald shall be closed. Only raise the issue here if it
+has been reproduced with the Herald demonstration app.
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**Smartphone and App information (REQUIRED):**
+
+- Device: [e.g. Seed nRF 52840 MDK USB]
+- Device exact model (if known): [e.g. if using additional custom hardware/libraries/OS] 
+- OS exact version: [e.g. nRF Connect SDK / Zephyr RTOS]
+- Herald demonstration app: [e.g. Venue Beacon, Wearable]
+- Herald demo app version: [e.g. Release ID (v1.2.0-beta3), latest develop branch, or commit ID]
+- Have you reproduced this issue on the latest 'develop' Herald branch?: [Yes, No]
+
+Without the above information the Herald team will be unable to reproduce 
+the issue, and thus also unable to fix and confirm the fix for the issue.
+
+If the above information is not provided then the issue will be marked
+as 'cannot reproduce'.
+
+**Severity (Project team may edit this section after reporting)**
+
+Please provide the following metrics (optional, can be filled in by project team if left blank):-
+
+- Likely How Widespread: [LOW = Less than 5% of installs of this (on beacons/wearables) variant, MEDIUM = 5%-50%, HIGH = More than 50%]
+- Reproducability: [NONE = Lab only/theoretical, or an unlikely user activity. LOW = Intermittent, unpredictable. MEDIUM = Occurs often, but unpredictable. HIGH = Easy to reproduce]
+- Impact: [NONE/LOW = Annoying, but functional. MEDIUM = Impacts function of the app/device, but there's a workaround. HIGH = Stops app/device functioning.]
+
+**To Reproduce**
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Screenshots or data files**
+
+If applicable, add screenshots to help explain your problem. Any data or log files you can share showing the issue would also be useful.
+
+**DEVELOPERS ONLY: Herald settings in use**
+
+If you are developing an app based on Herald, please indicate the settings you are using
+with Herald. In particular:-
+
+- Anything non-default from BLESensorConfiguration: [E.g. payload sharing frequency, and value]
+- The Payload provided used: [e.g. Secured Payload]
+- The Randomness provider used: [e.g. Secure Random]
+- Other (please indicate)
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Herald project website
+    url: https://vmware.github.io/herald
+    about: Our main project website for information
+  - name: Developer and integration guides
+    url: https://vmware.github.io/herald/guide/
+    about: Please review this guide for how to integrate Herald with your application
+  - name: Security HackerOne page
+    url: https://hackerone.com/vmware?type=team
+    about: VMware's HackerOne vulnerability disclosure programme
+  - name: Herald community
+    url: https://vmware.github.io/herald/community
+    about: Please join the Herald community to ask questions and get involved with development

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+**Please start with a use case description for a USER of this enhancement**
+
+[Who]  As a ????? [e.g. Wearable Developer / Venue owner]
+
+[What] I need to ??? [e.g. transmit my venue information]
+
+[Value] In order to achieve ??? and/or realise ??? benefit
+
+**Describe the potential solution you'd like**
+
+A clear and concise description of what you want to happen within Herald.
+
+**Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.
+
+**Relative priority**
+
+Please give an indication of a relative priority for this enhancement.

--- a/.github/ISSUE_TEMPLATE/security_report.md
+++ b/.github/ISSUE_TEMPLATE/security_report.md
@@ -1,0 +1,86 @@
+---
+name: Security report
+about: Report a specific security concern
+title: 'Security Report'
+labels: 'verify'
+assignees: ''
+
+---
+
+**WARNING*:: IF YOU ARE REPORTING AN ISSUE THAT COULD CAUSE
+IMMEDIATE SECURITY CONCERNS THAT PUT DEVICES OR PEOPLE AT RISK THEN
+PLEASE INSTEAD FOLLOW THE VMWARE SECURITY VULNERABILITY PROCEDURE:-
+
+https://hackerone.com/vmware?type=team
+
+For other security concerns, please continue.
+
+Note: Please report issues with upstream projects that we rely on (e.g. iOS Core Bluetooth, Android OS, etc.) via these two procedures too.
+
+**NOTE**: This issue tracker is for reporting bugs encountered with the
+Herald API and Herald testing applications themselves, not for issues with any downstream
+projects that use Herald within their apps. Please report issues with those apps to their
+developers and allow those developers to raise any upstream issues
+here themselves after they have completed their initial issue investigation. This prevents
+rework and delay in getting your issues resolved. Any issues
+raised referring to those apps here and not Herald shall be closed. Only raise the issue here if it
+has been reproduced with the Herald demonstration app.
+
+Example: If Herald provides 4 options for a piece of security functionality and a downstream app
+is using one you believe to be insecure, then please report this as a concern in their issues tracker.
+
+**Describe the security concern**
+
+A clear and concise description of what the security concern is.
+
+**Smartphone and App information (REQUIRED if you have produced an exploit):**
+
+- Device: [e.g. Seed nRF 52840 MDK USB]
+- Device exact model (if known): [e.g. if using additional custom hardware/libraries/OS] 
+- OS exact version: [e.g. nRF Connect SDK / Zephyr RTOS]
+- Herald demonstration app: [e.g. Venue Beacon, Wearable]
+- Herald demo app version: [e.g. Release ID (v1.2.0-beta3), latest develop branch, or commit ID]
+- Have you reproduced this issue on the latest 'develop' Herald branch?: [Yes, No]
+
+Without the above information the Herald team will be unable to reproduce 
+the issue, and thus also unable to fix and confirm the fix for the issue.
+
+If the above information is not provided then the issue will be marked
+as 'cannot reproduce'.
+
+**Severity (Project team may edit this section after reporting)**
+
+Please provide the following metrics (optional, can be filled in by project team if left blank):-
+
+- Likely How Widespread: [LOW = Less than 5% of installs of this (on beacons/wearables) variant, MEDIUM = 5%-50%, HIGH = More than 50%]
+- Reproducability: [NONE = Lab only/theoretical, or an unlikely user activity. LOW = Intermittent, unpredictable. MEDIUM = Occurs often, but unpredictable. HIGH = Easy to reproduce]
+- Impact: [LOW = Annoying, but functional. MEDIUM = Impacts function of the app/device, but there's a workaround. HIGH = Stops app/device functioning.]
+
+**Describe the potential solution you'd like**
+
+A clear and concise description of what you want to happen within Herald.
+
+**Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+**DEVELOPERS ONLY: Herald settings in use**
+
+If you are developing an app based on Herald, please indicate the settings you are using
+with Herald. In particular:-
+
+- Anything non-default from BLESensorConfiguration: [E.g. payload sharing frequency, and value]
+- The Payload provided used: [e.g. Secured Payload]
+- The Randomness provider used: [e.g. Secure Random]
+- Other (please indicate)
+
+**Additional context**
+
+Add any other context about the problem here.
+
+**Notification**
+
+DO NOT MODIFY THE BELOW - it will alert the maintainers once you submit your report.
+
+@vmware/herald-maintainers
+

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,35 @@
+---
+name: Pull request
+about: Submit a pull request
+title: 'Pull request'
+labels: ''
+assignees: ''
+
+---
+
+Realted to # .
+
+or
+
+Fixes # .
+
+Changes proposed in this pull request:-
+- ?
+- ?
+- ?
+
+Signed-off-by: Firstname Surname <your@emailaddress.com>
+
+**Checklist prior to submission**:-
+
+- [ ] Have you added a line to **EVERY** commit to this PR with Signed-off-by: Forename Surname <your@emailaddress.com> ? (This is required for us to be able to merge your contributions)
+   - See the CONTRIBUTING.md file in this repository for information as to why this is important.
+- [ ] Have you Linked to a known feature/bug ID via 'Related to' or 'Fixes', above?
+- [ ] (Optional best practice) Is your branch named feature-ISSUENUM ? (See GitFlow for why this is relevant)
+
+
+**Notification**
+
+Please do not edit the below. It will notify the maintainers once you submit your PR.
+
+@vmware/herald-maintainers

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Reporting security issues
+
+To report issues in live software, or upstream dependencies of our project's software,
+please follow the VMware HackerOne reporting procedure outlined below and include
+this project repository's URL:-
+
+https://hackerone.com/vmware?type=team
+
+This shall be routed to the maintainers of this open source project.
+
+To report a general concern around security please fill in a new issue
+using the 'security report' template on our GitHub Issues page for this project.
+
+https://github.com/vmware/herald-for-cpp/issues/new


### PR DESCRIPTION
Fixes #9. Adds GitHub issues and PR templates
- Issues templates
- PR template
- Guidance on information required
- Auto tagging of issues
- Auto notification of maintainers
- Advice for PR submitters
- SECURITY.md document
Signed-off-by: Adam Fowler <adamfowleruk@gmail.com>